### PR TITLE
added padding to scrollDistance rounding function to be able to sort val...

### DIFF
--- a/jquery.scrolldepth.js
+++ b/jquery.scrolldepth.js
@@ -150,8 +150,11 @@
     }
 
     function rounded(scrollDistance) {
-      // Returns String
-      return (Math.floor(scrollDistance/250) * 250).toString();
+      // Returns underscore padded String
+      var pad = "____________";   // 10^12-1 pixels should be enough for most pages ;>
+      var roundedDistance = (Math.floor(scrollDistance/250) * 250).toString();
+      var paddedRoundedDistance = (pad+roundedDistance).slice(-pad.length);
+      return paddedRoundedDistance;
     }
 
     /*


### PR DESCRIPTION
...ues in GA

Since this value is a label (string), you have to add some padding to be able to sort it in proper order in GA - other way you'll get:
1000
10000
2000
so basically it'll be sorted alphabetically.
before: https://www.dropbox.com/s/zvkldu7lnbv5vfu/Screenshot%202014-08-07%2011.25.38.jpg
after: https://www.dropbox.com/s/mlcxvzc1jb5bapm/Screenshot%202014-08-07%2011.48.12.jpg
less readable but sortable


i've tried with zeros at first but it was completely unreadable: https://www.dropbox.com/s/hiukj8bwucb6s8t/Screenshot%202014-08-07%2011.29.40.jpg

padding solution from:
http://stackoverflow.com/a/9744576/465064
(fastest and most elegant one)