### PR TITLE
Fix name in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Scroll Depth",
+  "name": "scroll-depth",
   "main": "jquery.scrolldepth.js",
   "version": "0.6.0",
   "homepage": "http://scrolldepth.parsnip.io",


### PR DESCRIPTION
From the [bower.json spec on the `name` attribute](https://github.com/bower/bower.json-spec#name):

> - Should be slug style for simplicity, consistency and compatibility. Example: `unicorn-cake`
> - Lowercase, a-z, can contain digits, 0-9, can contain dash or dot but not start/end with them.

Currently, `bower install scroll-depth` installs older version 0.4.1. This change should fix that issue.
