### PR TITLE
Allow GTM override

### DIFF
--- a/jquery.scrolldepth.js
+++ b/jquery.scrolldepth.js
@@ -14,7 +14,8 @@
     percentage: true,
     userTiming: true,
     pixelDepth: true,
-    nonInteraction: true
+    nonInteraction: true,
+    gtmOverride: false
   };
 
   var $window = $(window),
@@ -52,7 +53,7 @@
       classicGA = true;
     }
 
-    if (typeof dataLayer !== "undefined" && typeof dataLayer.push === "function") {
+    if (typeof dataLayer !== "undefined" && typeof dataLayer.push === "function" && !options.gtmOverride) {
       googleTagManager = true;
     }
 


### PR DESCRIPTION
I needed this fix for a recent project, so I thought it might be worth committing back. 

While analytics is often implemented through GTM, this isn't necessarily the case, and the current version doesn't work on pages where GTM is included but doesn't implement GA.