### PR TITLE
Fix for issue #31 - Specify DOM element to act as the bottom of the page

### DIFF
--- a/jquery.scrolldepth.js
+++ b/jquery.scrolldepth.js
@@ -14,15 +14,16 @@
     percentage: true,
     userTiming: true,
     pixelDepth: true,
-    nonInteraction: true
+    nonInteraction: true,
+    bottomElement: ''
   };
 
   var $window = $(window),
-    cache = [],
-    lastPixelDepth = 0,
-    universalGA,
-    classicGA,
-    standardEventHandler;
+      cache = [],
+      lastPixelDepth = 0,
+      universalGA,
+      classicGA,
+      standardEventHandler;
 
   /*
    * Plugin
@@ -228,15 +229,11 @@
        * account for dynamic DOM changes.
        */
 
-      var docHeight = $(document).height(),
-        winHeight = window.innerHeight ? window.innerHeight : $window.height(),
-        scrollDistance = $window.scrollTop() + winHeight,
-
-        // Recalculate percentage marks
-        marks = calculateMarks(docHeight),
-
-        // Timing
-        timing = +new Date - startTime;
+      var docHeight = options.bottomElement ? $(options.bottomElement).offset().top : $(document).height(),
+          winHeight = window.innerHeight ? window.innerHeight : $window.height(),
+          scrollDistance = $window.scrollTop() + winHeight,
+          marks = calculateMarks(docHeight),
+          timing = +new Date - startTime;
 
       // If all marks already hit, unbind scroll event
       if (cache.length >= 4 + options.elements.length) {


### PR DESCRIPTION
This pull request allows you to specify a DOM element to act as the bottom of the page. This helps deal with websites that have large footers or comments sections where you are only interested who has read through the blog or post content. Without this feature the scroll depth may never reach 100% and depending on the number of comments / size of footer may vary from content to content. A blog post could have a comments section 10x the length of the blog content, in which case someone who reads the entire blog but stops at the comments might not even cause a 25% tick mark event to fire. 

The bottom element is specified as a normal jQuery selector string.