### PR TITLE
Fix issue where plugin isn't available via AMD or CommonJS module loaders.

### DIFF
--- a/jquery.scrolldepth.js
+++ b/jquery.scrolldepth.js
@@ -317,5 +317,8 @@
       init();
 
     };
+  
+    // UMD export
+    return $.scrollDepth;
 
 }));


### PR DESCRIPTION
First, thank you for your work on this plugin!

**The problem:** The plugin wasn't being exposed from the factory, so the AMD and CommonJS parts of the UMD weren't actually exporting anything usable for any application using either of those loaders.

**The fix:** Return the entire plugin to make it available to AMD and CommonJS module loaders. This is in line with the common UMD pattern, and does not break compatibility with the typical global variable definition. 

See the "exposed public method" comment in this [UMD explanation](http://davidbcalhoun.com/2014/what-is-amd-commonjs-and-umd/#umd-universal-module-definition) for a simplified version of what was added here.